### PR TITLE
Load template from xinetd cookbook

### DIFF
--- a/providers/service.rb
+++ b/providers/service.rb
@@ -18,6 +18,7 @@ end
 
 def service_def_template(disabled)
   template "/etc/xinetd.d/#{new_resource.name}" do
+    cookbook new_resource.cookbook
     source "service.erb"
     variables :name => new_resource.service_name,
     :options => xinetd_options,

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -1,5 +1,6 @@
 actions :enable, :disable
 
+attribute :cookbook, :kind_of => String, :default => "xinetd"
 attribute :service_name, :name_attribute => true
 
 XinetdServiceHelpers::OPTIONS.each do |opt|


### PR DESCRIPTION
I noticed when I included the `xinetd` cookbook in my cookbook's dependencies and used the `xinetd_service` resource from one of my recipes, it ends up trying to load the `service.erb` template from my own cookbook's templates rather than from the `xinetd` cookbook.

This change ensures that the template is loaded from the `xinetd` cookbook. If necessary, this can be overridden by specifying the `cookbook` attribute in the resource.