### PR TITLE
Suppress warning already initialized constant

### DIFF
--- a/libraries/xinetd_service_helpers.rb
+++ b/libraries/xinetd_service_helpers.rb
@@ -8,7 +8,7 @@ module XinetdServiceHelpers
              :env, :passenv, :port, :redirect, :bind, :interface, :banner,
              :banner_success, :banner_failure, :per_source, :cps, :max_load,
              :groups, :mdns, :umask, :enabled, :rlimit_as, :rlimit_files,
-             :rlimit_cpus, :rlimit_data, :rlimit_rss, :rlimit_stack, :deny_time ]
+             :rlimit_cpus, :rlimit_data, :rlimit_rss, :rlimit_stack, :deny_time ] unless defined? OPTIONS
 
   def self.xinetd_bool(bool)
     bool ? "yes" : "no"


### PR DESCRIPTION
Suppress following warning: already initialized constant XinetdServiceHelpers::OPTIONS
While executing Chefspec tests when xinetd recipe is called from a wrapper cookbook (https://github.com/haapp/w_percona)